### PR TITLE
Allowing to exclude secret on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ firebase = new Firebase
 <br />
 
 #### • firebase.secret
+---
 If you wish not to share your *secret*, please follow the next steps.
 
 1. Simply, do not use *secret* on your code. (remove it if you have already)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ This module is based on [Firebase's REST API](https://firebase.google.com/docs/r
 | :---                                                                                                                                                    |
 | [**1) Properties**](https://github.com/marckrenn/framer-Firebase#1-properties)                                                                          |
 | \|--- [firebase**.projectID**, **.secret**](https://github.com/marckrenn/framer-Firebase#-firebaseprojectid-firebasesecret)                             |
-| \|--- [firebase**.debug**](https://github.com/marckrenn/framer-Firebase#-firebasedebug)                                                                 |
+| \|--- [firebase**.secret**](https://github.com/marckrenn/framer-Firebase#-firebasesecret)                                   |
+| \|--- [firebase**.debug**](https://github.com/marckrenn/framer-Firebase#-firebasedebug)                                                                |
 | \|--- [firebase**.status**](https://github.com/marckrenn/framer-Firebase#-firebasestatus-read-only)                                                     |
 | [**2) Methods**](https://github.com/marckrenn/framer-Firebase#2-methods)                                                                                |
 | \|--- [firebase**.get**()](https://github.com/marckrenn/framer-Firebase#-firebasegetpath-callback-parameters)                                           |
@@ -110,6 +111,23 @@ firebase = new Firebase
 | ![gif for ants I](http://i.giphy.com/xT4uQFz8q6HAHKkfi8.gif) | ![gif for ants II](http://i.giphy.com/3o6ZtnLC6wkxSZLY0U.gif) |
 
 > **Protip:** Contrary to what I did in the gif, I advise you **NOT** to share your Firebase *secret* publicly, as it allow others to alter the data stored in your database. If you do so by accident, you can always revoke access by deleting the shared *secret* and creating a new one at https://firebase.google.com → *Console* → *Project Settings* → *Database* → *Database Secrets*.
+
+<br />
+
+#### • firebase.secret
+If you wish not to share your *secret*, please follow the next steps.
+
+1. Simply, do not use *secret* on your code. (remove it if you have already)
+2. Go to *Console* → *YourProject* → *Database* → *RULES*
+3. Change the rules of `.read` and `.write` to `true` like the following:
+```json
+{
+  "rules": {
+    ".read": "true",
+    ".write": "true"
+  }
+}
+```
 
 <br />
 

--- a/firebase.coffee
+++ b/firebase.coffee
@@ -26,8 +26,9 @@ class exports.Firebase extends Framer.BaseClass
 		@secret    = @options.secret    ?= null
 		@debug     = @options.debug     ?= false
 		@_status                        ?= "disconnected"
-		super
 
+		@secretEndPoint = if @secret then "?auth=#{@secret}" else ""
+		super
 
 		console.log "Firebase: Connecting to Firebase Project '#{@projectID}' ... \n URL: 'https://#{@projectID}.firebaseio.com'" if @debug
 		@.onChange "connection"
@@ -35,7 +36,7 @@ class exports.Firebase extends Framer.BaseClass
 
 	request = (project, secret, path, callback, method, data, parameters, debug) ->
 
-		url = "https://#{project}.firebaseio.com#{path}.json?auth=#{secret}"
+		url = "https://#{project}.firebaseio.com#{path}.json#{secret}"
 
 
 		unless parameters is undefined
@@ -87,11 +88,11 @@ class exports.Firebase extends Framer.BaseClass
 
 	# Available methods
 
-	get:    (path, callback,       parameters) -> request(@projectID, @secret, path, callback, "GET",    null, parameters, @debug)
-	put:    (path, data, callback, parameters) -> request(@projectID, @secret, path, callback, "PUT",    data, parameters, @debug)
-	post:   (path, data, callback, parameters) -> request(@projectID, @secret, path, callback, "POST",   data, parameters, @debug)
-	patch:  (path, data, callback, parameters) -> request(@projectID, @secret, path, callback, "PATCH",  data, parameters, @debug)
-	delete: (path, callback,       parameters) -> request(@projectID, @secret, path, callback, "DELETE", null, parameters, @debug)
+	get:    (path, callback,       parameters) -> request(@projectID, @secretEndPoint, path, callback, "GET",    null, parameters, @debug)
+	put:    (path, data, callback, parameters) -> request(@projectID, @secretEndPoint, path, callback, "PUT",    data, parameters, @debug)
+	post:   (path, data, callback, parameters) -> request(@projectID, @secretEndPoint, path, callback, "POST",   data, parameters, @debug)
+	patch:  (path, data, callback, parameters) -> request(@projectID, @secretEndPoint, path, callback, "PATCH",  data, parameters, @debug)
+	delete: (path, callback,       parameters) -> request(@projectID, @secretEndPoint, path, callback, "DELETE", null, parameters, @debug)
 
 
 
@@ -100,7 +101,7 @@ class exports.Firebase extends Framer.BaseClass
 
 		if path is "connection"
 
-			url = "https://#{@projectID}.firebaseio.com/.json?auth=#{@secret}"
+			url = "https://#{@projectID}.firebaseio.com/.json#{@secretEndPoint}"
 			currentStatus = "disconnected"
 			source = new EventSource(url)
 
@@ -121,7 +122,7 @@ class exports.Firebase extends Framer.BaseClass
 
 		else
 
-			url = "https://#{@projectID}.firebaseio.com#{path}.json?auth=#{@secret}"
+			url = "https://#{@projectID}.firebaseio.com#{path}.json#{@secretEndPoint}"
 			source = new EventSource(url)
 			console.log "Firebase: Listening to changes made to '#{path}' \n URL: '#{url}'" if @debug
 


### PR DESCRIPTION
Hello. Currently, the module always require secret key and force to share it when the Framer prototype is shared on cloud. Therefore, I thought about making secret optional. I understand this is not a complete solution regarding security, however, it seemed still better than not sharing secret on public.