### PR TITLE
fixed problem on using parameters without secret

### DIFF
--- a/firebase.coffee
+++ b/firebase.coffee
@@ -17,7 +17,7 @@ class exports.Firebase extends Framer.BaseClass
 		@debug     = @options.debug     ?= false
 		@_status                        ?= "disconnected"
 
-		@secretEndPoint = if @secret then "?auth=#{@secret}" else ""
+		@secretEndPoint = if @secret then "auth=#{@secret}" else ""
 		super
 
 		console.log "Firebase: Connecting to Firebase Project '#{@projectID}' ... \n URL: 'https://#{@projectID}.firebaseio.com'" if @debug
@@ -26,7 +26,7 @@ class exports.Firebase extends Framer.BaseClass
 
 	request = (project, secret, path, callback, method, data, parameters, debug) ->
 
-		url = "https://#{project}.firebaseio.com#{path}.json#{secret}"
+		url = "https://#{project}.firebaseio.com#{path}.json?#{secret}"
 
 
 		unless parameters is undefined


### PR DESCRIPTION
Without secret, the request url missed `?` and resulted 404 response when there are parameters.
Here, I have tried to fix it in simple way by adding `?` to url directly.